### PR TITLE
Handle overlapping rectangles

### DIFF
--- a/src/rum-speedindex.js
+++ b/src/rum-speedindex.js
@@ -63,12 +63,9 @@ var RUMSpeedIndex = function(win) {
                        'left': Math.max(elRect.left, 0),
                        'bottom': Math.min(elRect.bottom, (win.innerHeight || doc.documentElement.clientHeight)),
                        'right': Math.min(elRect.right, (win.innerWidth || doc.documentElement.clientWidth))};
-      if (intersect.bottom <= intersect.top ||
-          intersect.right <= intersect.left) {
-        intersect = false;
-      } else {
-        intersect.area = (intersect.bottom - intersect.top) * (intersect.right - intersect.left);
-      }
+
+      // Ignore the surface area of elements that are outside of the visible viewport
+      intersect.area = Math.max((intersect.bottom - intersect.top) * (intersect.right - intersect.left), 0);
     }
     return intersect;
   };

--- a/src/rum-speedindex.js
+++ b/src/rum-speedindex.js
@@ -64,8 +64,12 @@ var RUMSpeedIndex = function(win) {
                        'bottom': Math.min(elRect.bottom, (win.innerHeight || doc.documentElement.clientHeight)),
                        'right': Math.min(elRect.right, (win.innerWidth || doc.documentElement.clientWidth))};
 
-      // Ignore the surface area of elements that are outside of the visible viewport
-      intersect.area = Math.max((intersect.bottom - intersect.top) * (intersect.right - intersect.left), 0);
+      var onScreenHeight = intersect.bottom - intersect.top;
+      var onScreenWidth = intersect.right - intersect.left;
+      // Ignore the surface area of elements that are outside of the visible viewport. Zero height elements can have visible children.
+      if (onScreenWidth <=0 || onScreenHeight < 0)
+          return false;
+      intersect.area = onScreenWidth * onScreenHeight;
     }
     return intersect;
   };


### PR DESCRIPTION
Hey Pat,

While testing RUMSpeedIndex I realized that often it counts more pixels than there are in the viewport. Looking into it, I found that overlapping rectangles were counted twice, which resulted in big discrepancies, especially in the case of a background image on the page's body which is mostly covered.

I tested my changes manually and they seem to work well, but could you run them by your benchmark and compare them to the previous results?

Cheers :)
Yoav
