### PR TITLE
Conditionally export `RUMSpeedIndex` from module

### DIFF
--- a/src/rum-speedindex.js
+++ b/src/rum-speedindex.js
@@ -270,3 +270,7 @@ var RUMSpeedIndex = function(win) {
   */
   return SpeedIndex;
 };
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = RUMSpeedIndex;
+}


### PR DESCRIPTION
Export `RumSpeedIndex` from `rum-speedindex.js` using UMD-style conditional (if in an environment that supports `module.exports`).  This would allow other modules to reference the `RumSpeedIndex` function.