### PR TITLE
Use getEntriesByName method to get performance entries by name and type

### DIFF
--- a/src/rum-speedindex.js
+++ b/src/rum-speedindex.js
@@ -139,13 +139,10 @@ var RUMSpeedIndex = function(win) {
   var GetFirstPaint = function() {
     // Try the standardized paint timing api
     try {
-      var entries = performance.getEntriesByType('paint');
-      for (var i = 0; i < entries.length; i++) {
-        if (entries[i]['name'] == 'first-paint') {
-          navStart = performance.getEntriesByType("navigation")[0].startTime;
-          firstPaint = entries[i].startTime - navStart;
-          break;
-        }
+      var entries = performance.getEntriesByName('first-paint', 'paint');
+      if (entries && entries.length) {
+        navStart = performance.getEntriesByType("navigation")[0].startTime;
+        firstPaint = entries[0].startTime - navStart;
       }
     } catch(e) {
     }


### PR DESCRIPTION
We were copying the fix from [this commit](https://github.com/WPO-Foundation/RUM-SpeedIndex/commit/811b8f8e) into our fork and found a minor optimization, figured we'd open a PR.

Cheers.