### PR TITLE
Fixed RUM Speed Index calculation when using Responsive images

### DIFF
--- a/src/rum-speedindex.js
+++ b/src/rum-speedindex.js
@@ -96,7 +96,7 @@ var RUMSpeedIndex = function(win) {
 
       // check for Images
       if (el.tagName == 'IMG') {
-        CheckElement(el, el.src);
+        CheckElement(el, el.currentSrc || el.src);
       }
       // Check for background images
       if (style['background-image']) {


### PR DESCRIPTION
When `srcset` is used on images the `src` attribute is ignored and the browser renders based on the viewport size. The `currentSrc` attribute is the right attribute to check in such cases.
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/currentSrc

How does this impact RUM Speed Index?
When calculating Speed Index the algorithm right now relies on `src` attribute, however what is rendered on the screen is a totally different image source. 
When the time of render is retrieved for an image node in this case, 0 is returned causing a miscalculation in speed index.

What's my fix?
Use `currentSrc` when available and fallback to using `src` attribute for older browsers.

Change we noticed on our end after the fix?
The following graph shows our fixed RUM speed index value. This is much more accurate and compliments with the WPT Speed Index test agents.
![image](https://user-images.githubusercontent.com/11497412/52504863-bb20a880-2bb7-11e9-9fa1-1b897d022a0d.png)
